### PR TITLE
feat(inlineDirectiveRule, blockDirectiveRule): added content validation

### DIFF
--- a/index.js
+++ b/index.js
@@ -284,7 +284,7 @@ function inlineDirectiveRule(state, silent) {
     // Markdown's design that paired `[]` doesn't need to be escaped
     // avoids "escape melaleuca" like `[\[\\[\\]\]]`. Clever design.
     const isValidContent = handler(state, content, dests, attrs, contentStart, contentEnd, state.pos, pos);
-    if (!isValidContent) return false;
+    if (isValidContent === false) return false;
   }
 
   state.pos = pos;
@@ -382,7 +382,7 @@ function blockDirectiveRule(state, startLine, endLine, silent) {
       inlineContentStart, inlineContentEnd,
       startLine, nextLine
     );
-    if (!isValidContent) return false;
+    if (isValidContent === false) return false;
   }
 
   state.line = nextLine;

--- a/index.js
+++ b/index.js
@@ -283,7 +283,8 @@ function inlineDirectiveRule(state, silent) {
     //
     // Markdown's design that paired `[]` doesn't need to be escaped
     // avoids "escape melaleuca" like `[\[\\[\\]\]]`. Clever design.
-    handler(state, content, dests, attrs, contentStart, contentEnd, state.pos, pos);
+    const isValidContent = handler(state, content, dests, attrs, contentStart, contentEnd, state.pos, pos);
+    if (!isValidContent) return false;
   }
 
   state.pos = pos;
@@ -374,13 +375,14 @@ function blockDirectiveRule(state, startLine, endLine, silent) {
   if (nextLine === -1) return false; // cannot find matched close mark (:::)
   const content = state.getLines(startLine + 1, nextLine - 1, state.sCount[startLine], true);
   if (!silent) {
-    handler(
+    const isValidContent = handler(
       state, content, contentTitle, inlineContent, dests, attrs,
       startLine + 1, nextLine - 1,
       contentTitleStart, contentTitleEnd,
       inlineContentStart, inlineContentEnd,
       startLine, nextLine
     );
+    if (!isValidContent) return false;
   }
 
   state.line = nextLine;


### PR DESCRIPTION
@hilookas 
Now there are two checks that allow you not to execute the directive:

1. checking for the validity of the directive with [parseDirective](https://github.com/hilookas/markdown-it-directive/blob/master/index.js#L266)
2. checking for the [presence of a handler](https://github.com/hilookas/markdown-it-directive/blob/master/index.js#L271)

At the same time a similar plugin [markdown-it-container](https://github.com/markdown-it/markdown-it-container) also [allows you to check the validity of the content](https://github.com/markdown-it/markdown-it-container/blob/master/index.mjs#L53). In this pull request, I suggest returning `true` or `false` from handler as content validation.

This feature is useful because it will allow the author of the plugin not to describe what the content of the token should be in case of incorrect content, but simply not to process this directive