### PR TITLE
updated types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import DefaultMarkdownIt from 'markdown-it';
+import DefaultMarkdownIt, {PluginSimple} from 'markdown-it';
 import * as StateInline from 'markdown-it/lib/rules_inline/state_inline';
 import * as StateBlock from 'markdown-it/lib/rules_block/state_block';
 
@@ -28,8 +28,8 @@ interface BlockHandlerArgs {
     directiveStartLine: number;
     directiveEndLine: number;
 }
-type InlineHandler = (args: Partial<DirectiveInlineHandlerArgs>) => boolean | void;
-type BlockHandler = (args: Partial<DirectiveBlockHandlerArgs>) => boolean | void;
+type InlineHandler = (args: DirectiveInlineHandlerArgs) => boolean | void;
+type BlockHandler = (args: DirectiveBlockHandlerArgs) => boolean | void;
 
 export type DirectiveInlineHandler = InlineHandler;
 export type DirectiveInlineHandlerArgs = InlineHandlerArgs;
@@ -51,6 +51,6 @@ declare module 'markdown-it' {
     export interface MarkdownItWithDirectives extends MarkdownIt {}
 }
 
-declare function load(md: MarkdownIt): void;
+declare function load(): PluginSimple;
 
 export default load;


### PR DESCRIPTION
@hilookas 
1. I replaced the type with a simple plugin so that I did not have to cast
2. I also removed the partition, because parameters will always be passed to the function, initially I used a partition so that the user in his handler did not describe all the parameters if he did not need them, but it is more correct not to use it, and the user can use the syntax with _ for unnecessary parameters