### PR TITLE
fix: correct parse inline directive without content and dests

### DIFF
--- a/index.js
+++ b/index.js
@@ -228,7 +228,7 @@ function parseDirective(state, src, pos, max, allowSpaceBetween) {
         dests = [ [ 'link', ref.href ], [ 'string', ref.title ] ];
         pos = destsEnd + 1;
       }
-    } else {
+    } else if (content !== undefined) {
       const ref = state.env.references[md.utils.normalizeReference(content)];
       if (ref) {
         dests = [ [ 'link', ref.href ], [ 'string', ref.title ] ];

--- a/test.js
+++ b/test.js
@@ -338,6 +338,14 @@ nextlineend
       ===
       '{"directive":"aaa(B)","content":">  text\\n","contentTitle":"","inlineContent":"5542","dests":[["link","/aaa"]],"attrs":{"class":"cls"}}'
     );
+    // should correct parse inline directive markup without content and dests, while the markdown markup contains references
+    assert(
+      md.render(`:dir
+
+  [ref]: https://example.com/`)
+      ===
+      '<p>:dir</p>\n'
+    )
   } ],
 ];
 


### PR DESCRIPTION
Fixed #5 