### PR TITLE
fix(headingPriority): fixed heading influence on directive

### DIFF
--- a/index.js
+++ b/index.js
@@ -422,7 +422,7 @@ function load(md) {
   md.blockDirectives = {}
 
   md.inline.ruler.push('inline_directive', inlineDirectiveRule);
-  md.block.ruler.before('paragraph', 'block_directive', blockDirectiveRule);
+  md.block.ruler.before('heading', 'block_directive', blockDirectiveRule);
 }
 
 module.exports = load;

--- a/test.js
+++ b/test.js
@@ -390,6 +390,15 @@ text
         '{"directive":"aaa(B)","content":"text\\n","contentTitle":""}'
     );
 
+    assert(
+        'should process directive before heading and keep dash in content',
+        md.render(`:::aaa
+-
+:::`)
+        ,
+        '{"directive":"aaa(B)","content":"-\\n","contentTitle":""}'
+    );
+
   } ],
 ];
 


### PR DESCRIPTION
Fixed an issue where an lheading immediately following an opening directive would take higher precedence and break the directive.

```
:::block
-
:::
```

was rendered to
```
<h2>:::block</h2>
<p>:::</p>
```